### PR TITLE
FAIMS-906: Allow duplicating TabGroups.

### DIFF
--- a/faims-android-app/src/au/org/intersect/faims/android/beanshell/BeanShellLinker.java
+++ b/faims-android-app/src/au/org/intersect/faims/android/beanshell/BeanShellLinker.java
@@ -719,9 +719,10 @@ public class BeanShellLinker implements IFAIMSRestorable {
 		return null;
 	}
 	
-	public void autoSaveTabGroup(String tabGroupRef, String uuid,
-			List<Geometry> geometry, List<? extends Attribute> attributes,
-			SaveCallback callback, boolean newRecord, boolean blocking) {
+	// This method is used internally by the AutoSaveManager and not directly called by any logic API call
+	public void saveTabGroupWithBlockingOption(String tabGroupRef, String uuid, List<Geometry> geometry, 
+			List<? extends Attribute> attributes, SaveCallback callback, 
+			boolean newRecord, boolean blocking) {
 		TabGroupHelper.saveTabGroupInBackground(this, tabGroupRef, uuid, geometry, attributes, callback, newRecord, blocking);
 	}
 	
@@ -731,7 +732,8 @@ public class BeanShellLinker implements IFAIMSRestorable {
 	}
 	
 	public void saveTabGroup(String ref, String uuid, List<Geometry> geometry, 
-			List<? extends Attribute> attributes, SaveCallback callback, boolean enableAutoSave) {
+			List<? extends Attribute> attributes, SaveCallback callback, 
+			boolean enableAutoSave) {
 		if (enableAutoSave) {
 			boolean newRecord = uuid == null;
 			if (newRecord) {

--- a/faims-android-app/src/au/org/intersect/faims/android/managers/AutoSaveManager.java
+++ b/faims-android-app/src/au/org/intersect/faims/android/managers/AutoSaveManager.java
@@ -156,7 +156,7 @@ public class AutoSaveManager implements IFAIMSRestorable {
 			if (pauseCounter == 0) {
 				
 				if (lock()) {
-					linker.autoSaveTabGroup(tabGroupRef, uuid, geometry, attributes, new SaveCallback() {
+					linker.saveTabGroupWithBlockingOption(tabGroupRef, uuid, geometry, attributes, new SaveCallback() {
 	
 						@Override
 						public void onError(String message) {


### PR DESCRIPTION
change saveTabGroup logic API call to always save entire tabgroup when entityId passed in is null; This will keep existing behaviour and also allow tabgroups to be duplicated.

@matthew-intersect can you review this commit.
