### PR TITLE
FAIMS-913: Revert change to saveTabGroup + Add duplicateTabGroup API

### DIFF
--- a/faims-android-app/assets/ui_commands.bsh
+++ b/faims-android-app/assets/ui_commands.bsh
@@ -189,7 +189,7 @@ duplicateTabGroup(String ref, List geometry, List attributes, List excludeAttrib
 /**
   * Disable autosave for tabgroup
   *
-  * @param ref the refernce  of the tab group
+  * @param ref the reference  of the tab group
   */
 disableAutoSave(String ref) {
   linker.disableAutoSave(ref);

--- a/faims-android-app/assets/ui_commands.bsh
+++ b/faims-android-app/assets/ui_commands.bsh
@@ -174,6 +174,28 @@ saveTabGroup(String ref, String id, List geometry, List attributes, SaveCallback
 }
 
 /**
+  * Duplicate the tab group with the following reference.
+  *
+  * @param ref the reference of the tab group
+  * @param geometry the geometry list of the record
+  * @param attributes additional attributes to save for the record
+  * @param excludeAttributes exclude attributes from being saved to the record
+  * @param callback code to execute when saving is finished
+  */
+duplicateTabGroup(String ref, List geometry, List attributes, List excludeAttributes, SaveCallback callback){
+  linker.duplicateTabGroup(ref, geometry, attributes, callback, excludeAttributes, callback);
+}
+
+/**
+  * Disable autosave for tabgroup
+  *
+  * @param ref the refernce  of the tab group
+  */
+disableAutoSave(String ref) {
+  linker.disableAutoSave(ref);
+}
+
+/**
   * Save the tab with the following reference.
   *
   * @param ref the reference of the tab group

--- a/faims-android-app/src/au/org/intersect/faims/android/beanshell/BeanShellLinker.java
+++ b/faims-android-app/src/au/org/intersect/faims/android/beanshell/BeanShellLinker.java
@@ -745,9 +745,9 @@ public class BeanShellLinker implements IFAIMSRestorable {
 		}
 	}
 	
-	public void duplicateTabGroup(String ref, String uuid, List<Geometry> geometry, 
-			List<? extends Attribute> attributes, SaveCallback callback, List<? extends Attribute> excludeAttributes) {
-		TabGroupHelper.duplicateTabGroupInBackground(this, ref, geometry, attributes, callback, excludeAttributes);
+	public void duplicateTabGroup(String ref, List<Geometry> geometry, 
+			List<? extends Attribute> attributes, List<? extends Attribute> excludeAttributes, SaveCallback callback) {
+		TabGroupHelper.duplicateTabGroupInBackground(this, ref, geometry, attributes, excludeAttributes, callback);
 	}
 	
 	public void disableAutoSave(String ref) {

--- a/faims-android-app/src/au/org/intersect/faims/android/beanshell/BeanShellLinker.java
+++ b/faims-android-app/src/au/org/intersect/faims/android/beanshell/BeanShellLinker.java
@@ -719,9 +719,10 @@ public class BeanShellLinker implements IFAIMSRestorable {
 		return null;
 	}
 	
-	public void autoSaveTabGroup(String tabGroupRef, String uuid,
-			List<Geometry> geometry, List<? extends Attribute> attributes,
-			SaveCallback callback, boolean newRecord, boolean blocking) {
+	// This method is used internally by the AutoSaveManager and not directly called by any logic API call
+	public void saveTabGroupWithBlockingOption(String tabGroupRef, String uuid, List<Geometry> geometry, 
+			List<? extends Attribute> attributes, SaveCallback callback, 
+			boolean newRecord, boolean blocking) {
 		TabGroupHelper.saveTabGroupInBackground(this, tabGroupRef, uuid, geometry, attributes, callback, newRecord, blocking);
 	}
 	
@@ -731,7 +732,8 @@ public class BeanShellLinker implements IFAIMSRestorable {
 	}
 	
 	public void saveTabGroup(String ref, String uuid, List<Geometry> geometry, 
-			List<? extends Attribute> attributes, SaveCallback callback, boolean enableAutoSave) {
+			List<? extends Attribute> attributes, SaveCallback callback, 
+			boolean enableAutoSave) {
 		if (enableAutoSave) {
 			boolean newRecord = uuid == null;
 			if (newRecord) {

--- a/faims-android-app/src/au/org/intersect/faims/android/beanshell/BeanShellLinker.java
+++ b/faims-android-app/src/au/org/intersect/faims/android/beanshell/BeanShellLinker.java
@@ -744,6 +744,15 @@ public class BeanShellLinker implements IFAIMSRestorable {
 			TabGroupHelper.saveTabGroupInBackground(this, ref, uuid, geometry, attributes, callback, uuid == null, false);
 		}
 	}
+	
+	public void duplicateTabGroup(String ref, String uuid, List<Geometry> geometry, 
+			List<? extends Attribute> attributes, SaveCallback callback, List<? extends Attribute> excludeAttributes) {
+		TabGroupHelper.duplicateTabGroupInBackground(this, ref, geometry, attributes, callback, excludeAttributes);
+	}
+	
+	public void disableAutoSave(String ref) {
+		autoSaveManager.disable(ref);
+	}
 
 	public void saveTab(String ref, String uuid, List<Geometry> geometry, 
 			List<? extends Attribute> attributes, SaveCallback callback) {

--- a/faims-android-app/src/au/org/intersect/faims/android/beanshell/TabGroupHelper.java
+++ b/faims-android-app/src/au/org/intersect/faims/android/beanshell/TabGroupHelper.java
@@ -157,10 +157,8 @@ public class TabGroupHelper {
 	private static void checkTabGroupForChangesAndSaveTabGroup(final BeanShellLinker linker, final TabGroup tabGroup, final String uuid, final List<Geometry> geometry, 
 			final List<? extends Attribute> attributes, final SaveCallback callback, final boolean newRecord) throws Exception {
 		final AutoSaveManager autoSaveManager = linker.getAutoSaveManager();
-		if (newRecord) {
-			collectAttributesAndSaveTabGroup(linker, tabGroup, uuid, geometry, attributes, callback, newRecord);
-		} else if (tabGroup.hasChanges()) {
-			if (tabGroup.hasRecord(uuid)) {
+		if (tabGroup.hasChanges()) {
+			if (newRecord || tabGroup.hasRecord(uuid)) {
 				collectAttributesAndSaveTabGroup(linker, tabGroup, uuid, geometry, attributes, callback, newRecord);
 			} else {
 				loadRecordAndSaveTabGroup(linker, tabGroup, uuid, geometry, attributes, callback, newRecord);
@@ -236,84 +234,105 @@ public class TabGroupHelper {
 		}
 	}
 	
-	@SuppressWarnings("unchecked")
 	private static void collectAttributesAndSaveTabGroup(BeanShellLinker linker, final TabGroup tabGroup, String uuid, List<Geometry> geometry, 
 			List<? extends Attribute> attributes, final SaveCallback callback, boolean newRecord) throws Exception {
 		synchronized(TabGroupHelper.class) {
 			if (tabGroup.getArchEntType() != null) {
-				List<EntityAttribute> entityAttributes = new ArrayList<EntityAttribute>();
-				if (attributes != null) {
-					entityAttributes.addAll((List<EntityAttribute>) attributes);
-				}
-				entityAttributes.addAll(getEntityAttributesFromTabGroup(linker, tabGroup));	
-				
-				final List<EntityAttribute> updatedAttributes = entityAttributes;
-				if (geometry != null || !entityAttributes.isEmpty()) {
-					DatabaseHelper.saveArchEnt(linker, uuid, tabGroup.getArchEntType(), geometry, entityAttributes, new SaveCallback() {
-
-						@Override
-						public void onError(String message) {
-							callback.onError(message);
-						}
-
-						@Override
-						public void onSave(String uuid, boolean newRecord) {
-							// update cached entity
-							ArchEntity entity = tabGroup.getArchEntity();
-							if (entity != null) {
-								entity.updateAttributes(updatedAttributes);
-							}
-							callback.onSave(uuid, newRecord);
-						}
-
-						@Override
-						public void onSaveAssociation(String entityId,
-								String relationshpId) {
-						}
-						
-					}, newRecord, true);
-				} else {
-					callback.onSave(uuid,  newRecord);
-				}
+				collectEntityAttributesAndSaveEntity(linker, tabGroup, uuid, geometry, attributes, callback, newRecord, null);
 			} else if (tabGroup.getRelType() != null) {
-				List<RelationshipAttribute> relationshipAttributes = new ArrayList<RelationshipAttribute>();
-				if (attributes != null) {
-					relationshipAttributes.addAll((List<RelationshipAttribute>) attributes);
-				}
-				relationshipAttributes.addAll(getRelationshipAttributesFromTabGroup(linker, tabGroup));
-				
-				final List<RelationshipAttribute> updatedAttributes = relationshipAttributes;
-				if (geometry != null || !relationshipAttributes.isEmpty()) {
-					DatabaseHelper.saveRel(linker, uuid, tabGroup.getRelType(), geometry, relationshipAttributes, new SaveCallback() {
-
-						@Override
-						public void onError(String message) {
-							callback.onError(message);
-						}
-
-						@Override
-						public void onSave(String uuid, boolean newRecord) {
-							// update cached relationship
-							Relationship relationship = tabGroup.getRelationship();
-							if (relationship != null) {
-								relationship.updateAttributes(updatedAttributes);
-							}
-							callback.onSave(uuid, newRecord);
-						}
-
-						@Override
-						public void onSaveAssociation(String entityId,
-								String relationshpId) {
-						}
-						
-					}, newRecord, true);
-				} else {
-					callback.onSave(uuid,  newRecord);
-				}
+				collectRelationshipAttributesAndSaveRelationship(linker, tabGroup, uuid, geometry, attributes, callback, newRecord, null);
 			} else {
 				throw new Exception("no type specified for tabgroup");
 			}
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static void collectEntityAttributesAndSaveEntity(BeanShellLinker linker, final TabGroup tabGroup, String uuid, List<Geometry> geometry, 
+			List<? extends Attribute> attributes, final SaveCallback callback, boolean newRecord, List<? extends Attribute> excludeAttributes) {
+		List<EntityAttribute> entityAttributes = new ArrayList<EntityAttribute>();
+		if (attributes != null) {
+			entityAttributes.addAll((List<EntityAttribute>) attributes);
+		}
+		entityAttributes.addAll(getEntityAttributesFromTabGroup(linker, tabGroup));	
+		
+		filterAttributes(entityAttributes, excludeAttributes);
+		
+		final List<EntityAttribute> updatedAttributes = entityAttributes;
+		if (geometry != null || !entityAttributes.isEmpty()) {
+			DatabaseHelper.saveArchEnt(linker, uuid, tabGroup.getArchEntType(), geometry, entityAttributes, new SaveCallback() {
+
+				@Override
+				public void onError(String message) {
+					callback.onError(message);
+				}
+
+				@Override
+				public void onSave(String uuid, boolean newRecord) {
+					// update cached entity
+					ArchEntity entity = tabGroup.getArchEntity();
+					if (entity != null) {
+						entity.updateAttributes(updatedAttributes);
+					}
+					callback.onSave(uuid, newRecord);
+				}
+
+				@Override
+				public void onSaveAssociation(String entityId,
+						String relationshpId) {
+				}
+				
+			}, newRecord, true);
+		} else {
+			callback.onSave(uuid,  newRecord);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static void collectRelationshipAttributesAndSaveRelationship(BeanShellLinker linker, final TabGroup tabGroup, String uuid, List<Geometry> geometry, 
+			List<? extends Attribute> attributes, final SaveCallback callback, boolean newRecord, List<? extends Attribute> excludeAttributes) {
+		List<RelationshipAttribute> relationshipAttributes = new ArrayList<RelationshipAttribute>();
+		if (attributes != null) {
+			relationshipAttributes.addAll((List<RelationshipAttribute>) attributes);
+		}
+		relationshipAttributes.addAll(getRelationshipAttributesFromTabGroup(linker, tabGroup));
+		
+		filterAttributes(relationshipAttributes, excludeAttributes);
+		
+		final List<RelationshipAttribute> updatedAttributes = relationshipAttributes;
+		if (geometry != null || !relationshipAttributes.isEmpty()) {
+			DatabaseHelper.saveRel(linker, uuid, tabGroup.getRelType(), geometry, relationshipAttributes, new SaveCallback() {
+
+				@Override
+				public void onError(String message) {
+					callback.onError(message);
+				}
+
+				@Override
+				public void onSave(String uuid, boolean newRecord) {
+					// update cached relationship
+					Relationship relationship = tabGroup.getRelationship();
+					if (relationship != null) {
+						relationship.updateAttributes(updatedAttributes);
+					}
+					callback.onSave(uuid, newRecord);
+				}
+
+				@Override
+				public void onSaveAssociation(String entityId,
+						String relationshpId) {
+				}
+				
+			}, newRecord, true);
+		} else {
+			callback.onSave(uuid,  newRecord);
+		}
+	}
+	
+	private static void filterAttributes(
+			List<? extends Attribute> attributes,
+			List<? extends Attribute> excludeAttributes) {
+		
 	}
 
 	@SuppressWarnings("unchecked")
@@ -603,6 +622,25 @@ public class TabGroupHelper {
 				
 			});
 		}
+	}
+	
+	protected static void duplicateTabGroupInBackground(final BeanShellLinker linker, final String ref, final List<Geometry> geometry, 
+			final List<? extends Attribute> attributes, final SaveCallback callback, final List<? extends Attribute> excludeAttributes) {
+		AsyncTask<Void,Void,Void> task = new AsyncTask<Void,Void,Void>() {
+
+			@Override
+			protected Void doInBackground(Void... params) {
+				try {
+					final TabGroup tabGroup = linker.getTabGroup(ref);
+					collectEntityAttributesAndSaveEntity(linker, tabGroup, null, geometry, attributes, callback, true, excludeAttributes);
+				} catch (Exception e) {
+					TabGroupHelper.onError(linker, callback, null, "Error duplicating tab group " + ref, "Error executing duplicate tab group onerror callback");
+				}
+				return null;
+			}
+			
+		};
+		task.execute();
 	}
 
 }

--- a/faims-android-app/src/au/org/intersect/faims/android/beanshell/TabGroupHelper.java
+++ b/faims-android-app/src/au/org/intersect/faims/android/beanshell/TabGroupHelper.java
@@ -332,7 +332,15 @@ public class TabGroupHelper {
 	private static void filterAttributes(
 			List<? extends Attribute> attributes,
 			List<? extends Attribute> excludeAttributes) {
-		
+		ArrayList<Attribute> subtractAttributes = new ArrayList<Attribute>();
+		for (Attribute a : attributes) {
+			for (Attribute ea : excludeAttributes) {
+				if (a.getName().equals(ea.getName())) {
+					subtractAttributes.add(a);
+				}
+			}
+		}
+		attributes.removeAll(subtractAttributes);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -625,7 +633,7 @@ public class TabGroupHelper {
 	}
 	
 	protected static void duplicateTabGroupInBackground(final BeanShellLinker linker, final String ref, final List<Geometry> geometry, 
-			final List<? extends Attribute> attributes, final SaveCallback callback, final List<? extends Attribute> excludeAttributes) {
+			final List<? extends Attribute> attributes, final List<? extends Attribute> excludeAttributes, final SaveCallback callback) {
 		AsyncTask<Void,Void,Void> task = new AsyncTask<Void,Void,Void>() {
 
 			@Override

--- a/faims-android-app/src/au/org/intersect/faims/android/managers/AutoSaveManager.java
+++ b/faims-android-app/src/au/org/intersect/faims/android/managers/AutoSaveManager.java
@@ -156,7 +156,7 @@ public class AutoSaveManager implements IFAIMSRestorable {
 			if (pauseCounter == 0) {
 				
 				if (lock()) {
-					linker.autoSaveTabGroup(tabGroupRef, uuid, geometry, attributes, new SaveCallback() {
+					linker.saveTabGroupWithBlockingOption(tabGroupRef, uuid, geometry, attributes, new SaveCallback() {
 	
 						@Override
 						public void onError(String message) {

--- a/faims-android-app/src/au/org/intersect/faims/android/ui/activity/handlers/WifiBroadcastReceiver.java
+++ b/faims-android-app/src/au/org/intersect/faims/android/ui/activity/handlers/WifiBroadcastReceiver.java
@@ -6,6 +6,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.net.wifi.WifiManager;
+import au.org.intersect.faims.android.app.FAIMSApplication;
 import au.org.intersect.faims.android.log.FLog;
 import au.org.intersect.faims.android.net.ServerDiscovery;
 import au.org.intersect.faims.android.ui.activity.ShowModuleActivity;
@@ -21,6 +22,7 @@ public class WifiBroadcastReceiver extends BroadcastReceiver {
 
 	public WifiBroadcastReceiver(ShowModuleActivity activity) {
 		this.activityRef = new WeakReference<ShowModuleActivity>(activity);
+		FAIMSApplication.getInstance().injectMembers(this);
 	}
 
 	@Override


### PR DESCRIPTION
Rervert changes to saveTabGroup api that allowed duplicating tabgroup but introduce unwanted bug with saving empty tabgroups. Instead added new api called to duplicateTabGroup.
